### PR TITLE
Allow installing both v1 and v2 of php-http/curl-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "~7.2",
         "jane-php/open-api": "^5.2",
-        "php-http/curl-client": "^1.1",
+        "php-http/curl-client": "^1.1 || ^2.0",
         "guzzlehttp/psr7": "^1.6",
         "php-http/message": "^1.7"
     },


### PR DESCRIPTION
When working on Upgrade to Symfony 5.4 in https://github.com/acquia/mc-cf-cloud-agent/pull/114 I needed to install php-http/curl-client v2.

Once this PR is merged to `master` we need to change the dependency back to `"mautic-inc/mega-openapi-php-sdk": "dev-master"` on [this line](https://github.com/acquia/mc-cf-cloud-agent/blob/2f7dd38d2cab81f3dbfaec7b6589ad25c57a9e47/composer.json#L24).